### PR TITLE
fix bug: create token is not a fucntion when clicking one of the buttons

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -3,7 +3,7 @@ const Button = ({ text, disabled, createToken, width }) => {
     <button
       className={`${width} bg-yellow-400 text-black text-md font-semibold uppercase px-4 py-2.5 rounded-full font-button hover:bg-transparent outline outline-yellow-400 hover:outline-yellow-400 focus:outline-4`}
       disabled={disabled}
-      onClick={() => createToken()}
+      onClick={() => (createToken ? createToken() : null)}
     >
       {text}
     </button>


### PR DESCRIPTION

## Description
This PR fix a bug that occurs when you click a button that  does not use the `createToken` prop.
- The bug was happening because we were trying to call the function `createToken` every time we click the button component, but for the `add` and the `join existing list` buttons we aren't passing the `createToken` function as prop.
- I added a check in the onClick, so it will only call the` createToken` if it exists.
<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

## Related Issue
closes #43 
<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->


## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|   ✓| :bug: Bug fix              |
|   | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |



## Testing Steps / QA Criteria
- From your terminal, pull down this branch with `git pull origin rb-fix-bug-createToken` and check that branch out with `rb-fix-bug-createToken`
- Then run `npm start`
- Open the console and click the `add` item, you will notice that there is no error.
<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->

