### PR TITLE
Bugfix: navbar shows over last list item preventing scroll-down

### DIFF
--- a/src/components/List.js
+++ b/src/components/List.js
@@ -21,23 +21,26 @@ const List = () => {
   return (
     <>
       <Header title={'Smart Shopping List'} imageSrc={bag} />
-      {listeningError && <p>{listeningError}</p>}
-      {isLoading && <p>loading...</p>}
-      {data && data.length === 0 && <WelcomingPrompt />}
-      {data && data.length !== 0 && <Search setSearchTerm={setSearchTerm} />}
+      <section className="mb-24">
+        {listeningError && <p>{listeningError}</p>}
+        {isLoading && <p>loading...</p>}
+        {data && data.length === 0 && <WelcomingPrompt />}
+        {data && data.length !== 0 && <Search setSearchTerm={setSearchTerm} />}
 
-      {data &&
-        data
-          .filter((item) => {
-            return item.itemName
-              .toLowerCase()
-              .includes(searchTerm.toLowerCase());
-          })
-          .map((item) => (
-            <ul key={item.id} className="flex">
-              <ListItem itemData={item} />
-            </ul>
-          ))}
+        {data &&
+          data
+            .filter((item) => {
+              return item.itemName
+                .toLowerCase()
+                .includes(searchTerm.toLowerCase());
+            })
+
+            .map((item) => (
+              <ul key={item.id} className="flex">
+                <ListItem itemData={item} />
+              </ul>
+            ))}
+      </section>
     </>
   );
 };


### PR DESCRIPTION
## Description

This PR fixes the issue of the navbar showing over the last list item, preventing further scroll-down.

- In `List.js`,  I added a `section` and gave it a margin bottom with the class `mb-24`.

## Related Issue

Closes #49

## Acceptance Criteria

The navbar shoudn`t block any list item and scroll-down should be possible.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|   ✓ | :bug: Bug fix              |
|   | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

![bug-fix-before (2)](https://user-images.githubusercontent.com/84801660/170453348-68b47b68-e116-4cba-b3ed-a9953231beb6.JPG)


### After

![bug-fix-2-after](https://user-images.githubusercontent.com/84801660/170453673-199eaa8b-ae0a-4c73-a7a3-96b31cd688c3.JPG)



## Testing Steps / QA Criteria

- From your terminal, pull down this branch with `git pull origin jm-bugfix-navbar-shows-over-last-list-item-preventing-scroll-down` and check that branch out with `git checkout  jm-bugfix-navbar-shows-over-last-list-item-preventing-scroll-down`
- Check that the navbar doesn`t block any list item and that scroll-down is possible.


